### PR TITLE
added to_currency function to LiquidJS step

### DIFF
--- a/functions/liquid/1.1/function.json
+++ b/functions/liquid/1.1/function.json
@@ -1,0 +1,41 @@
+{
+  "description": "Render templates using LiquidJS",
+  "label": "Liquid",
+  "category": "Templates",
+  "icon": {
+    "name": "BracketsCurly",
+    "color": "Orange"
+  },
+  "options": [
+    {
+      "meta": {
+        "type": "MultilineText",
+        "validations": { "required": true }
+      },
+      "name": "template",
+      "label": "Template",
+      "configuration": {
+        "placeholder": "{{firstName}} {{lastName}}"
+      }
+    },
+    {
+      "info": "Map the values that you want to use in your template",
+      "label": "Context",
+      "meta": {
+        "type": "Map"
+      },
+      "name": "context"
+    },
+    {
+      "meta": {
+        "type": "Output",
+        "output": {
+          "type": "Text"
+        }
+      },
+      "name": "as",
+      "label": "As"
+    }
+  ],
+  "yields": "NONE"
+}

--- a/functions/liquid/1.1/index.js
+++ b/functions/liquid/1.1/index.js
@@ -1,0 +1,24 @@
+import groupBy from 'lodash.groupby';
+import Liquid from '../../utils/liquid.min';
+import { toCurrency } from '../../utils/tocurrency';
+
+const liquid = async ({ template, context = [] }) => {
+  const engine = new Liquid();
+
+  engine.registerFilter('group', (collection, key) => groupBy(collection, key));
+  engine.plugin(toCurrency);
+  
+  const as = engine.parseAndRenderSync(
+    template,
+    context.reduce((ctx, { key, value }) => {
+      ctx[key] = value;
+      return ctx;
+    }, {}),
+  );
+
+  return {
+    as,
+  };
+};
+
+export default liquid;

--- a/functions/utils/tocurrency.js
+++ b/functions/utils/tocurrency.js
@@ -1,0 +1,27 @@
+function toCurrency(Liquid) {
+    this.registerFilter(
+      "to_currency",
+      function (
+        value,
+        currency,
+        fractionDigits,
+        decimalSeparator,
+        thousandSeparator,
+      ) {
+        // Default values if parameters are not provided
+        fractionDigits = fractionDigits || 2;
+        decimalSeparator = decimalSeparator || ".";
+        thousandSeparator = thousandSeparator || null;
+  
+        const parts = Number(value).toFixed(fractionDigits).toString().split(".");
+  
+        parts[0] = thousandSeparator
+          ? parts[0].replace(/\B(?=(\d{3})+(?!\d))/g, thousandSeparator)
+          : parts[0];
+  
+          return currency + parts.join(decimalSeparator);
+      }
+    );
+  }
+  module.exports.toCurrency = toCurrency;
+  


### PR DESCRIPTION
to_currency added to LiquidJS
This is missing in the LiquidJS NPM package
Formatting is exactly the same as Classic Gen syntax