### PR TITLE
feat: add array type to output and bump to v1.2 PFR-912

### DIFF
--- a/__tests__/expression/1.2/index.test.js
+++ b/__tests__/expression/1.2/index.test.js
@@ -1,0 +1,73 @@
+import expression from '../../../functions/expression/1.2';
+
+describe('Expression', () => {
+  const name = 'John Doe';
+  const age = '17';
+  test('It handles a expression with input variables', async () => {
+    const result = await expression({
+      expression: '"{{name}}"',
+      variables: [{ key: 'name', value: name }],
+    });
+    expect(result).toEqual({ result: name });
+  });
+
+  test('It evaluate two string values', async () => {
+    const result = await expression({
+      expression: "'{{first_name}}' + ' ' + '{{last_name}}'",
+      variables: [
+        { key: 'first_name', value: 'John' },
+        { key: 'last_name', value: 'Doe' },
+      ],
+    });
+
+    expect(result).toEqual({ result: 'John Doe' });
+  });
+
+  test('It evaluate a ternary expression', async () => {
+    const result = await expression({
+      expression: '{{age}} > 17 ? true : false',
+      variables: [{ key: 'age', value: age }],
+    });
+
+    expect(result).toEqual({ result: false });
+  });
+
+  test('It evaluate counting two numbers', async () => {
+    const result = await expression({
+      expression: '{{number1}} + {{number2}}',
+      variables: [
+        { key: 'number1', value: '1' },
+        { key: 'number2', value: '1' },
+      ],
+    });
+
+    expect(result).toEqual({ result: 2 });
+  });
+
+  test('It respects pipelines', async () => {
+    const result = await expression({
+      expression: '"hello || world"',
+      variables: [],
+    });
+
+    expect(result).toEqual({ result: 'hello || world' });
+  });
+
+  test('It respects interpolating falsy values', async () => {
+    const result = await expression({
+      expression: '{{count}} || 1',
+      variables: [{ key: 'count', value: 0 }],
+    });
+
+    expect(result).toEqual({ result: 1 });
+  });
+
+  test('It handles arrays', async () => {
+    const result = await expression({
+      expression: '"{{#names}}{{.}}, {{/names}}"',
+      variables: [{ key: 'names', value: ['John', 'Jane'] }],
+    });
+
+    expect(result).toEqual({ result: 'John, Jane, ' });
+  });
+});

--- a/blocks/expression.json
+++ b/blocks/expression.json
@@ -1,5 +1,5 @@
 {
   "dependencies": [],
-  "functions": ["expression 1.1"],
+  "functions": ["expression 1.2"],
   "includes": ["functions/utils"]
 }

--- a/functions/expression/1.2/function.json
+++ b/functions/expression/1.2/function.json
@@ -1,0 +1,60 @@
+{
+  "description": "Evaluate a javascript expression (use {{name_of_your_value}} to interpolate values).",
+  "label": "Expression",
+  "category": "Misc",
+  "icon": {
+    "name": "ExpressionIcon",
+    "color": "Orange"
+  },
+  "options": [
+    {
+      "meta": {
+        "type": "MultilineText",
+        "validations": { "required": true }
+      },
+      "name": "expression",
+      "label": "Expression",
+      "configuration": {
+        "placeholder": "\"{{first_name}}\" + \" \" + \"{{last_name}}\""
+      }
+    },
+    {
+      "info": "Map the values that you want to use in your expression.",
+      "label": "Variables",
+      "meta": {
+        "type": "Map"
+      },
+      "name": "variables"
+    },
+    {
+      "info": "The result of the expression.",
+      "meta": {
+        "type": "Output",
+        "validations": {
+          "required": true
+        },
+        "output": {
+          "anyOf": [
+            {
+              "type": "Text"
+            },
+            {
+              "type": "Boolean"
+            },
+            {
+              "type": "Number"
+            },
+            {
+              "type": "Array",
+              "schemaModel": "schemaModel",
+              "dataType": "SCHEMA"
+            }
+          ]
+        }
+      },
+      "name": "result",
+      "label": "Result"
+    }
+  ],
+  "yields": "NONE"
+}

--- a/functions/expression/1.2/index.js
+++ b/functions/expression/1.2/index.js
@@ -1,0 +1,17 @@
+import templayed from '../../utils/templayed';
+
+const expression = async ({ expression: expres, variables }) => {
+  const variableMap = variables.reduce(
+    (previousValue, currentValue) => ({
+      ...previousValue,
+      [currentValue.key]: currentValue.value,
+    }),
+    {},
+  );
+
+  return {
+    result: new Function(`return ${templayed(expres)(variableMap)}`)(),
+  };
+};
+
+export default expression;


### PR DESCRIPTION
Actions are needlessly complex sometimes. If I have an expression with a little code of javascript that generates an array it can only be outputted to text. This feature enables the builder to directly typecast the variable to type array.