### PR TITLE
feat: add liquid 1.2 with to_currency filter

### DIFF
--- a/__tests__/liquid/1.2/index.test.js
+++ b/__tests__/liquid/1.2/index.test.js
@@ -1,0 +1,128 @@
+import { test } from 'vitest';
+import liquid from '../../../functions/liquid/1.2';
+
+describe('LiquidJS', () => {
+  const name = 'Batman';
+  const characters = [
+    { name: 'Batman', team: 'Heroes' },
+    { name: 'Hulk', team: 'Heroes' },
+    { name: 'Iron Man', team: 'Heroes' },
+    { name: 'Joker', team: 'Villains' },
+    { name: 'Lex Luthor', team: 'Villains' },
+    { name: 'Mandarin', team: 'Villains' },
+    { name: 'Sandman', team: 'Villains' },
+    { name: 'Spider-Man', team: 'Heroes' },
+    { name: 'Superman', team: 'Heroes' },
+    { name: 'Venom', team: 'Villains' },
+  ];
+
+  test('It handles a template with a context', async () => {
+    const { as } = await liquid({
+      template: 'Hello, {{name}}!',
+      context: [{ key: 'name', value: name }],
+    });
+    expect(as).toEqual('Hello, Batman!');
+  });
+
+  test('It provides the standard Liquid tags', async () => {
+    const { as } = await liquid({
+      template: `
+        {% assign foo = "FOO" %}
+        {% if foo == "FOO" %}
+          Variable \`foo\` equals "FOO"
+        {% else %}
+          Variable \`foo\` not equals "FOO"
+        {% endif %}
+      `,
+    });
+    expect(as.trim()).toEqual('Variable `foo` equals "FOO"');
+  });
+
+  test('It provides the standard Liquid filters', async () => {
+    const { as } = await liquid({
+      template: '{{ name | append: ", welcome to LiquidJS!" | upcase }}',
+      context: [{ key: 'name', value: name }],
+    });
+    expect(as).toEqual('BATMAN, WELCOME TO LIQUIDJS!');
+  });
+
+  test('It is able to group an array of objects based on a key', async () => {
+    const { as } = await liquid({
+      template: `
+        {% assign groups = characters | group: "team" %}
+
+        {% for group in groups %}
+        Team: {{ group[0] }}
+
+        {% assign team = group[1] %}
+
+        {% for member in team %}
+        - {{ member.name }}
+        {% endfor %}
+
+        {% endfor %}
+      `,
+      context: [{ key: 'characters', value: characters }],
+    });
+    expect(as.replace(/\s+/g, ' ').trim()).toEqual(
+      'Team: Heroes - Batman - Hulk - Iron Man - Spider-Man - Superman Team: Villains - Joker - Lex Luthor - Mandarin - Sandman - Venom',
+    );
+  });
+
+  test('It handles a template variable with a context', async () => {
+    const { as } = await liquid({
+      templateVariable: 'Hello, {{name}}!',
+      context: [{ key: 'name', value: name }],
+    });
+    expect(as).toEqual('Hello, Batman!');
+  });
+
+  test('It preferes a template variable over template', async () => {
+    const { as } = await liquid({
+      template: 'Not {{name}}!',
+      templateVariable: 'Hello, {{name}}!',
+      context: [{ key: 'name', value: name }],
+    });
+    expect(as).toEqual('Hello, Batman!');
+  });
+
+  test('It formats a number as currency with default options', async () => {
+    const { as } = await liquid({
+      template: '{{ amount | toCurrency }}',
+      context: [{ key: 'amount', value: 1234567.891 }],
+    });
+    expect(as).toEqual('$1,234,567.89');
+  });
+
+  test('It formats a number as currency with custom symbol and separators', async () => {
+    const { as } = await liquid({
+      template: "{{ amount | toCurrency: '€', 2, '.', ',' }}",
+      context: [{ key: 'amount', value: 1234567.891 }],
+    });
+    expect(as).toEqual('€1.234.567,89');
+  });
+
+  test('It formats a negative number as currency', async () => {
+    const { as } = await liquid({
+      template: '{{ amount | toCurrency }}',
+      context: [{ key: 'amount', value: -1234.5 }],
+    });
+    expect(as).toEqual('-$1,234.50');
+  });
+
+  test('It supports zero decimals', async () => {
+    const { as } = await liquid({
+      template: "{{ amount | toCurrency: '$', 0 }}",
+      context: [{ key: 'amount', value: 1234.99 }],
+    });
+    expect(as).toEqual('$1,235');
+  });
+
+  test('It returns the original value when input is not numeric', async () => {
+    const { as } = await liquid({
+      template: '{{ amount | toCurrency }}',
+      context: [{ key: 'amount', value: 'not-a-number' }],
+    });
+    expect(as).toEqual('not-a-number');
+  });
+});

--- a/__tests__/liquid/1.2/index.test.js
+++ b/__tests__/liquid/1.2/index.test.js
@@ -88,7 +88,7 @@ describe('LiquidJS', () => {
 
   test('It formats a number as currency with default options', async () => {
     const { as } = await liquid({
-      template: '{{ amount | toCurrency }}',
+      template: '{{ amount | to_currency }}',
       context: [{ key: 'amount', value: 1234567.891 }],
     });
     expect(as).toEqual('$1,234,567.89');
@@ -96,7 +96,7 @@ describe('LiquidJS', () => {
 
   test('It formats a number as currency with custom symbol and separators', async () => {
     const { as } = await liquid({
-      template: "{{ amount | toCurrency: '€', 2, '.', ',' }}",
+      template: "{{ amount | to_currency: '€', 2, '.', ',' }}",
       context: [{ key: 'amount', value: 1234567.891 }],
     });
     expect(as).toEqual('€1.234.567,89');
@@ -104,7 +104,7 @@ describe('LiquidJS', () => {
 
   test('It formats a negative number as currency', async () => {
     const { as } = await liquid({
-      template: '{{ amount | toCurrency }}',
+      template: '{{ amount | to_currency }}',
       context: [{ key: 'amount', value: -1234.5 }],
     });
     expect(as).toEqual('-$1,234.50');
@@ -112,7 +112,7 @@ describe('LiquidJS', () => {
 
   test('It supports zero decimals', async () => {
     const { as } = await liquid({
-      template: "{{ amount | toCurrency: '$', 0 }}",
+      template: "{{ amount | to_currency: '$', 0 }}",
       context: [{ key: 'amount', value: 1234.99 }],
     });
     expect(as).toEqual('$1,235');
@@ -120,7 +120,7 @@ describe('LiquidJS', () => {
 
   test('It returns the original value when input is not numeric', async () => {
     const { as } = await liquid({
-      template: '{{ amount | toCurrency }}',
+      template: '{{ amount | to_currency }}',
       context: [{ key: 'amount', value: 'not-a-number' }],
     });
     expect(as).toEqual('not-a-number');

--- a/functions/liquid/1.2/function.json
+++ b/functions/liquid/1.2/function.json
@@ -1,0 +1,50 @@
+{
+  "description": "Render templates using LiquidJS",
+  "label": "Liquid",
+  "category": "Templates",
+  "icon": {
+    "name": "BracketsCurly",
+    "color": "Orange"
+  },
+  "options": [
+    {
+      "meta": {
+        "type": "MultilineText"
+      },
+      "name": "template",
+      "label": "Template",
+      "configuration": {
+        "placeholder": "{{firstName}} {{lastName}}"
+      }
+    },
+    {
+      "info": "Using a variable, for instance from an record object, a config or just a regular variable",
+      "meta": {
+        "type": "Value",
+        "allowedKinds": ["STRING"]
+      },
+      "name": "templateVariable",
+      "label": "Or choose a template variable"
+    },
+    {
+      "info": "Map the values that you want to use in your template",
+      "label": "Context",
+      "meta": {
+        "type": "Map"
+      },
+      "name": "context"
+    },
+    {
+      "meta": {
+        "type": "Output",
+        "validations": { "required": true },
+        "output": {
+          "type": "Text"
+        }
+      },
+      "name": "as",
+      "label": "As"
+    }
+  ],
+  "yields": "NONE"
+}

--- a/functions/liquid/1.2/index.js
+++ b/functions/liquid/1.2/index.js
@@ -30,7 +30,7 @@ const liquid = async ({ template, templateVariable, context = [] }) => {
   const engine = new Liquid();
 
   engine.registerFilter('group', (collection, key) => groupBy(collection, key));
-  engine.registerFilter('toCurrency', toCurrency);
+  engine.registerFilter('to_currency', toCurrency);
 
   const as = engine.parseAndRenderSync(
     templateVariable ?? template ?? '',

--- a/functions/liquid/1.2/index.js
+++ b/functions/liquid/1.2/index.js
@@ -1,0 +1,45 @@
+import groupBy from 'lodash.groupby';
+import Liquid from '../../utils/liquid.min';
+
+const toCurrency = (
+  value,
+  symbol = '$',
+  decimals = 2,
+  thousandsSeparator = ',',
+  decimalSeparator = '.',
+) => {
+  const number = Number(value);
+  if (Number.isNaN(number)) return value;
+
+  const sign = number < 0 ? '-' : '';
+  const [whole, fraction] = Math.abs(number).toFixed(decimals).split('.');
+  const wholeWithSeparator = whole.replace(
+    /\B(?=(\d{3})+(?!\d))/g,
+    thousandsSeparator,
+  );
+
+  return (
+    sign +
+    symbol +
+    wholeWithSeparator +
+    (fraction ? decimalSeparator + fraction : '')
+  );
+};
+
+const liquid = async ({ template, templateVariable, context = [] }) => {
+  const engine = new Liquid();
+
+  engine.registerFilter('group', (collection, key) => groupBy(collection, key));
+  engine.registerFilter('toCurrency', toCurrency);
+
+  const as = engine.parseAndRenderSync(
+    templateVariable ?? template ?? '',
+    Object.fromEntries(context.map(({ key, value }) => [key, value])),
+  );
+
+  return {
+    as,
+  };
+};
+
+export default liquid;

--- a/functions/utils/liquid.min.js
+++ b/functions/utils/liquid.min.js
@@ -3554,6 +3554,22 @@ const global = {};
           i = n.slice(0, e).join(' ');
         return n.length >= e && (i += r), i;
       },
+      toCurrency: function (t, e, r, n, i) {
+        void 0 === e && (e = '$'),
+          void 0 === r && (r = 2),
+          void 0 === n && (n = ','),
+          void 0 === i && (i = '.');
+        var s = Number(t);
+        if (isNaN(s)) return t;
+        var o = s < 0 ? '-' : '',
+          a = Math.abs(s).toFixed(r),
+          u = a.split('.'),
+          c = u[0],
+          l = 1 < u.length ? i + u[1] : '';
+        return (
+          o + e + c.replace(/\B(?=(\d{3})+(?!\d))/g, n) + l
+        );
+      },
     }),
     yn =
       ((mn.prototype.get = function (t) {

--- a/functions/utils/liquid.min.js
+++ b/functions/utils/liquid.min.js
@@ -3554,22 +3554,6 @@ const global = {};
           i = n.slice(0, e).join(' ');
         return n.length >= e && (i += r), i;
       },
-      toCurrency: function (t, e, r, n, i) {
-        void 0 === e && (e = '$'),
-          void 0 === r && (r = 2),
-          void 0 === n && (n = ','),
-          void 0 === i && (i = '.');
-        var s = Number(t);
-        if (isNaN(s)) return t;
-        var o = s < 0 ? '-' : '',
-          a = Math.abs(s).toFixed(r),
-          u = a.split('.'),
-          c = u[0],
-          l = 1 < u.length ? i + u[1] : '';
-        return (
-          o + e + c.replace(/\B(?=(\d{3})+(?!\d))/g, n) + l
-        );
-      },
     }),
     yn =
       ((mn.prototype.get = function (t) {


### PR DESCRIPTION
## Summary
- Adds a new `liquid` function version `1.2` that registers a `to_currency` filter via `engine.registerFilter`, mirroring how the existing `group` filter is wired up — the bundled `functions/utils/liquid.min.js` is left untouched.
- The filter formats a numeric value with a configurable currency symbol, decimal precision, and thousands/decimal separators. Signature: `value | to_currency: symbol = '$', decimals = 2, thousandsSeparator = ',', decimalSeparator = '.'`.

## Test plan
- [x] `pnpm test` — full suite passes (225/225)
- [x] `pnpm run lint` — clean
- [x] `pnpm run prettier:check` — clean
- [x] Default args: `{{ 1234567.891 | to_currency }}` → `$1,234,567.89`
- [x] Custom (EU-style): `{{ 1234567.891 | to_currency: '€', 2, '.', ',' }}` → `€1.234.567,89`
- [x] Negative: `{{ -1234.5 | to_currency }}` → `-$1,234.50`
- [x] Zero decimals: `{{ 1234.99 | to_currency: '$', 0 }}` → `$1,235`
- [x] Non-numeric input is returned unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)
